### PR TITLE
Update for v1.1.6 with GitLab 8.16.7-ee.0

### DIFF
--- a/index.html.md.erb
+++ b/index.html.md.erb
@@ -9,11 +9,11 @@ This is documentation for the [GitLab service for Pivotal Cloud Foundry](https:/
 
 <dl>
 <dt>Current GitLab for <a href="https://network.pivotal.io/products/pivotal-cf">Pivotal Cloud Foundry</a> Details</dt>
-<dd><strong>Version</strong>: 1.1.5 </dd>
-<dd><strong>Release Date</strong>: 3 February 2017</dd>
-<dd><strong>Software component version</strong>: GitLab Enterprise Edition 8.15.5</dd>
-<dd><strong>Compatible Ops Manager Version(s)</strong>: 1.8.x, 1.7.x, 1.6.x</dd>
-<dd><strong>Compatible Elastic Runtime Version(s)</strong>: 1.8.x, 1.7.x, 1.6.x</dd>
+<dd><strong>Version</strong>: 1.1.6 </dd>
+<dd><strong>Release Date</strong>: 7 March 2017</dd>
+<dd><strong>Software component version</strong>: GitLab Enterprise Edition 8.16.7</dd>
+<dd><strong>Compatible Ops Manager Version(s)</strong>: 1.9.x, 1.8.x, 1.7.x, 1.6.x</dd>
+<dd><strong>Compatible Elastic Runtime Version(s)</strong>: 1.9.x, 1.8.x, 1.7.x, 1.6.x</dd>
 <dd><strong>vSphere support?</strong> Yes</dd>
 <dd><strong>AWS support?</strong> Yes</dd>
 <dd><strong>OpenStack support?</strong> Yes</dd>
@@ -30,7 +30,7 @@ Consider the following compatibility information before upgrading GitLab for Piv
 </tr>
 <tr>
   <th> 1.8.x, 1.7.x, 1.6.x</th>
-  <td>From 1.1.0 to 1.1.4
+  <td>From 1.1.3 to 1.1.5
   </td>
 </tr>
 </table>

--- a/release.html.md.erb
+++ b/release.html.md.erb
@@ -5,6 +5,14 @@ owner: London Services
 
 Release notes for [GitLab for Pivotal Cloud Foundry](https://network.pivotal.io/products/p-gitlab)
 
+###1.1.6
+**Release Date: 7 March 2017**
+
+* Generally Available release
+* Upgradeable from the public release 1.1.3, 1.1.4, 1.1.5
+* GitLab Enterprise 8.16.7
+* Minor release, security update, bugfix
+
 ###1.1.5
 **Release Date: 3 February 2017**
 


### PR DESCRIPTION
Update to 1.1.6

* Contains GitLab EE 8.16.7-ee.0
* Now confirmed to work with 1.9.x of PCF & ER
* Set to upgrade from 1.1.3+, not 1.1.0