### PR TITLE
Add link to official GitLab PCF documentation for additional information. 

### DIFF
--- a/index.html.md.erb
+++ b/index.html.md.erb
@@ -80,4 +80,5 @@ Please provide any bugs, feature requests, or questions to [the Pivotal Cloud Fo
 
 ## Further Reading
 
+* [Additional information on the GitLab Tile](https://docs.gitlab.com/ee/install/pivotal/index.html)
 * [Official GitLab Documentation](http://doc.gitlab.com/ee/)


### PR DESCRIPTION
This PR adds a link at the bottom of the page to the official GitLab PCF Tile documentation on installation. Some additional information is there, which we should provide a link to from this page.