### PR TITLE
Updates for Tile v1.2.6 including GitLab EE 9.3.10.

### DIFF
--- a/index.html.md.erb
+++ b/index.html.md.erb
@@ -14,15 +14,15 @@ The following table provides version and version-support information about GitLa
     <th>Details</th>
     <tr>
         <td>Tile version</td>
-        <td>v1.2.5</td>
+        <td>v1.2.6</td>
     </tr>
     <tr>
         <td>Release date</td>
-        <td>August 11, 2017</td>
+        <td>August 17, 2017</td>
     </tr>
     <tr>
         <td>Software component version</td>
-        <td>GitLab Enterprise Edition v9.2.10</td>
+        <td>GitLab Enterprise Edition v9.3.10</td>
     </tr>
     <tr>
         <td>Compatible Ops Manager version(s)</td>
@@ -49,7 +49,7 @@ Consider the following compatibility information before upgrading GitLab for PCF
 </tr>
 <tr>
   <th> v1.9.x, v1.8.x, v1.7.x, v1.6.x</th>
-  <td>From v1.1.3 to v1.2.5
+  <td>From v1.2.0 to v1.2.6
   </td>
 </tr>
 </table>

--- a/release.html.md.erb
+++ b/release.html.md.erb
@@ -5,6 +5,15 @@ owner: Partners
 
 Release notes for [GitLab for Pivotal Cloud Foundry](https://network.pivotal.io/products/p-gitlab)
 
+### v1.2.6
+**Release Date: August 17, 2017**
+
+* Generally Available release
+* Upgradable from the public release v1.2.4 and v1.2.5
+* GitLab Enterprise v9.3.10
+* Minor release
+* More details in [9.3 release post](https://about.gitlab.com/2017/06/22/gitlab-9-3-released/)
+
 ### v1.2.5
 **Release Date: August 11, 2017**
 


### PR DESCRIPTION
- Contains
  - GitLab EE 9.2.10

- Release post: https://about.gitlab.com/2017/06/22/gitlab-9-3-released/