### PR TITLE
Update to 1.2.11 / GitLab EE 10.0.4

### DIFF
--- a/index.html.md.erb
+++ b/index.html.md.erb
@@ -16,10 +16,10 @@ owner: Partners
 
 This is documentation for [GitLab Enterprise Plus for Pivotal Cloud Foundry (PCF)](https://network.pivotal.io/products/p-gitlab).
 
-<p class="note warning"><strong>IMPORTANT</strong>: As of September 13, 2017, the GitLab Enterprise Plus for Pivotal Cloud Foundry tile on 
-  Pivotal Network has reached its End of Availability ("EoA") and is no longer available for download or sale through Pivotal. Current 
-  customers with active subscriptions will continue to receive support from GitLab through their subscription term. Pivotal and GitLab are 
-  collaborating on creating a new Kubernetes-based tile for the Pivotal Container Service. Please contact GitLab support with any 
+<p class="note warning"><strong>IMPORTANT</strong>: As of September 13, 2017, the GitLab Enterprise Plus for Pivotal Cloud Foundry tile on
+  Pivotal Network has reached its End of Availability ("EoA") and is no longer available for download or sale through Pivotal. Current
+  customers with active subscriptions will continue to receive support from GitLab through their subscription term. Pivotal and GitLab are
+  collaborating on creating a new Kubernetes-based tile for the Pivotal Container Service. Please contact GitLab support with any
   questions regarding GitLab Enterprise Plus for Pivotal Cloud Foundry.</p>
 
 ## Product Snapshot
@@ -31,15 +31,15 @@ The following table provides version and version-support information about GitLa
     <th>Details</th>
     <tr>
         <td>Tile version</td>
-        <td>v1.2.10</td>
+        <td>v1.2.11</td>
     </tr>
     <tr>
         <td>Release date</td>
-        <td>September 27, 2017</td>
+        <td>November 1, 2017</td>
     </tr>
     <tr>
         <td>Software component version</td>
-        <td>GitLab Enterprise Edition v9.5.5</td>
+        <td>GitLab Enterprise Edition v10.0.4</td>
     </tr>
     <tr>
         <td>Compatible Ops Manager version(s)</td>
@@ -66,7 +66,7 @@ Consider the following compatibility information before upgrading GitLab for PCF
 </tr>
 <tr>
   <th>v1.7.x through v1.12.x</th>
-  <td>From v1.2.4 to v1.2.9
+  <td>From v1.2.4 to v1.2.10
   </td>
 </tr>
 </table>

--- a/release.html.md.erb
+++ b/release.html.md.erb
@@ -5,6 +5,15 @@ owner: Partners
 
 Release notes for [GitLab for Pivotal Cloud Foundry](https://network.pivotal.io/products/p-gitlab)
 
+### v1.2.11
+**Release Date: November 1, 2017**
+
+* Release available to Select User Groups
+* Upgradable from the public releases v1.2.4, v1.2.5, v1.2.6, v1.2.7, v1.2.8, v1.2.9 and v1.2.10
+* GitLab Enterprise v10.0.4
+* Minor release
+* For more information, see [GitLab 10.0.4 Released](https://about.gitlab.com/2017/10/17/gitlab-10-dot-0-dot-4-security-release/)
+
 ### v1.2.10
 **Release Date: September 27, 2017**
 


### PR DESCRIPTION
Update index & release to show 1.2.11 from 1.2.4 through 1.2.9

Includes GitLab EE 10.0.4


(whitespace changes were automatic)