### PR TITLE
Update to 1.2.12 / GitLab EE 9.5.9

### DIFF
--- a/index.html.md.erb
+++ b/index.html.md.erb
@@ -31,15 +31,15 @@ The following table provides version and version-support information about GitLa
     <th>Details</th>
     <tr>
         <td>Tile version</td>
-        <td>v1.2.11</td>
+        <td>v1.2.12</td>
     </tr>
     <tr>
         <td>Release date</td>
-        <td>November 1, 2017</td>
+        <td>November 3, 2017</td>
     </tr>
     <tr>
         <td>Software component version</td>
-        <td>GitLab Enterprise Edition v10.0.4</td>
+        <td>GitLab Enterprise Edition v9.5.9</td>
     </tr>
     <tr>
         <td>Compatible Ops Manager version(s)</td>

--- a/release.html.md.erb
+++ b/release.html.md.erb
@@ -5,14 +5,14 @@ owner: Partners
 
 Release notes for [GitLab for Pivotal Cloud Foundry](https://network.pivotal.io/products/p-gitlab)
 
-### v1.2.11
-**Release Date: November 1, 2017**
+### v1.2.12
+**Release Date: November 3, 2017**
 
 * Release available to Select User Groups
 * Upgradable from the public releases v1.2.4, v1.2.5, v1.2.6, v1.2.7, v1.2.8, v1.2.9 and v1.2.10
-* GitLab Enterprise v10.0.4
-* Minor release
-* For more information, see [GitLab 10.0.4 Released](https://about.gitlab.com/2017/10/17/gitlab-10-dot-0-dot-4-security-release/)
+* GitLab Enterprise v9.9.5
+* Patch release
+* For more information, see [GitLab 9.5.9 Released](https://about.gitlab.com/2017/10/17/gitlab-10-dot-0-dot-4-security-release/)
 
 ### v1.2.10
 **Release Date: September 27, 2017**


### PR DESCRIPTION
PULLS 1.2.11 OUT OF DOCS!

Update index & release to show 1.2.12 from 1.2.4 through 1.2.10

Includes GitLab EE 9.5.9