### PR TITLE
GitLab Tile v1.2.13

### DIFF
--- a/index.html.md.erb
+++ b/index.html.md.erb
@@ -31,11 +31,11 @@ The following table provides version and version-support information about GitLa
     <th>Details</th>
     <tr>
         <td>Tile version</td>
-        <td>v1.2.12</td>
+        <td>v1.2.13</td>
     </tr>
     <tr>
         <td>Release date</td>
-        <td>November 3, 2017</td>
+        <td>November 7, 2017</td>
     </tr>
     <tr>
         <td>Software component version</td>

--- a/release.html.md.erb
+++ b/release.html.md.erb
@@ -5,8 +5,8 @@ owner: Partners
 
 Release notes for [GitLab for Pivotal Cloud Foundry](https://network.pivotal.io/products/p-gitlab)
 
-### v1.2.12
-**Release Date: November 3, 2017**
+### v1.2.13
+**Release Date: November 7, 2017**
 
 * Release available to Select User Groups
 * Upgradable from the public releases v1.2.4, v1.2.5, v1.2.6, v1.2.7, v1.2.8, v1.2.9 and v1.2.10


### PR DESCRIPTION
- Add 1.2.13 to docs
- Removes 1.2.12 from docs
- Contains fix for MySQL incompatibility