### PR TITLE
Bump to 1.4.4, include GitLab EE 10.4.4, PCF 2.0 support

### DIFF
--- a/index.html.md.erb
+++ b/index.html.md.erb
@@ -31,23 +31,23 @@ The following table provides version and version-support information about GitLa
     <th>Details</th>
     <tr>
         <td>Tile version</td>
-        <td>v1.4.3</td>
+        <td>v1.4.4</td>
     </tr>
     <tr>
         <td>Release date</td>
-        <td>February 7, 2018</td>
+        <td>March 2, 2018</td>
     </tr>
     <tr>
         <td>Software component version</td>
-        <td>GitLab Enterprise Edition v10.2.7</td>
+        <td>GitLab Enterprise Edition v10.4.4</td>
     </tr>
     <tr>
         <td>Compatible Ops Manager version(s)</td>
-        <td>v1.7.x through v1.12.x</td>
+        <td>v1.11.x through v2.0.x</td>
     </tr>
     <tr>
         <td>Compatible Elastic Runtime version(s)</td>
-        <td>v1.7.x through v1.12.x</td>
+        <td>v1.11.x through v2.0.x</td>
     </tr>
     <tr>
         <td>IaaS support</td>
@@ -65,7 +65,7 @@ Consider the following compatibility information before upgrading GitLab for PCF
   <th>Supported Upgrades from Imported GitLab Installation</th>
 </tr>
 <tr>
-  <th>v1.7.x through v1.12.x</th>
+  <th>v1.11.x through v2.0.x</th>
   <td>v1.3.0, v1.4.0
   </td>
 </tr>

--- a/release.html.md.erb
+++ b/release.html.md.erb
@@ -5,6 +5,16 @@ owner: Partners
 
 Release notes for [GitLab for Pivotal Cloud Foundry](https://network.pivotal.io/products/p-gitlab)
 
+### v1.4.4
+**Release Date: March 2, 2018**
+
+* Release available to Select User Groups
+* Upgradeable from the public releases v1.3.0 and v1.4.0
+* GitLab Enterprise v10.4.4
+* Minor release.
+* Introduces support for PCF 2.0.x
+* For more information, see [GitLab 10.4.4 released](https://about.gitlab.com/2018/02/16/gitlab-10-dot-4-dot-4-released/)
+
 ### v1.4.3
 **Release Date: February 7, 2018**
 

--- a/release.html.md.erb
+++ b/release.html.md.erb
@@ -11,7 +11,7 @@ Release notes for [GitLab for Pivotal Cloud Foundry](https://network.pivotal.io/
 * Release available to Select User Groups
 * Upgradeable from the public releases v1.3.0 and v1.4.0
 * GitLab Enterprise v10.4.4
-* Minor release.
+* Minor release
 * Introduces support for PCF 2.0.x
 * For more information, see [GitLab 10.4.4 released](https://about.gitlab.com/2018/02/16/gitlab-10-dot-4-dot-4-released/)
 


### PR DESCRIPTION
Bump to version 1.4.4 with GitLab EE v10.4.4 included.

Introduces support for PCF 2.0.x